### PR TITLE
Dockerの作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.4.5'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'com.google.cloud.tools.jib' version '3.0.0'
 }
 
 group = 'com.b1a9idps'
@@ -25,6 +26,20 @@ dependencies {
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+jib {
+    container {
+        ports ['8080']
+        jvmFlags = ['--enable-preview']
+    }
+    from {
+        image = 'openjdk:15-alpine'
+    }
+    to {
+        image = 'micrometer-prometheus-api'
+        tags = ['latest']
+    }
 }
 
 test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus:/etc/prometheus
+    command: "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - 9090:9090
+    restart: always
+  micrometer-prometheus-api:
+    image: micrometer-prometheus-api
+    container_name: micrometer-prometheus-api
+    ports:
+      - 18080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,9 @@ services:
     container_name: micrometer-prometheus-api
     ports:
       - 18080:8080
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    restart: always

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 10s
+  scrape_timeout: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'micrometer-prometheus'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets:
+        - micrometer-prometheus-api:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,5 @@
-
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus


### PR DESCRIPTION
- Actuatorで`GET /actuator/prometheus`を有効にする
- jibの追加
- APIとPrometheusとGrafanaをDockerで起動